### PR TITLE
Support for ReSharper 8.1

### DIFF
--- a/BuildPackages.ps1
+++ b/BuildPackages.ps1
@@ -2,7 +2,7 @@ msbuild .\ReSharperExtensions.sln /p:Configuration=Release
 
 pushd Deploy
 
-nuget pack JoarOyen.ReSharperExtensions.Macros.8.0.0.1.nuspec
-nuget pack JoarOyen.ReSharperExtensions.Livetemplates.8.0.0.1.nuspec
+nuget pack JoarOyen.ReSharperExtensions.Macros.nuspec
+nuget pack JoarOyen.ReSharperExtensions.Livetemplates.nuspec
 
 popd

--- a/Deploy/JoarOyen.ReSharperExtensions.LiveTemplates.nuspec
+++ b/Deploy/JoarOyen.ReSharperExtensions.LiveTemplates.nuspec
@@ -2,14 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>JoarOyen.ReSharperExtensions.LiveTemplates</id>
-    <version>8.0.0.1</version>
+    <version>8.0.0.2-EAP-20131112</version>
     <title>Joar Øyen's Live Templates for ReSharper</title>
     <authors>Joar Øyen</authors>
     <projectUrl>https://github.com/joaroyen/ReSharperExtensions</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A ReSharper DotSettings file with a Live Template example using macros for writing MSTest methods.</description>
-    <summary />
-    <releaseNotes>Support for ReSharper 8.0</releaseNotes>
+    <releaseNotes>Support for ReSharper 8.1</releaseNotes>
     <copyright>Copyright © 2013 Joar Øyen</copyright>
     <language>en-US</language>
     <tags>Macro, Testing</tags>
@@ -19,6 +18,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\JoarOyen.ReSharperExtensions.LiveTemplates.DotSettings" target="ReSharper\v8.0\settings\" />
+    <file src="..\JoarOyen.ReSharperExtensions.LiveTemplates.DotSettings" target="ReSharper\vAny\settings\" />
   </files>
 </package>

--- a/Deploy/JoarOyen.ReSharperExtensions.Macros.nuspec
+++ b/Deploy/JoarOyen.ReSharperExtensions.Macros.nuspec
@@ -2,14 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>JoarOyen.ReSharperExtensions.Macros</id>
-    <version>8.0.0.1</version>
+    <version>8.0.0.2-EAP-20131112</version>
     <title>Joar Øyen's Live Template Macros for ReSharper</title>
     <authors>Joar Øyen</authors>
     <projectUrl>https://github.com/joaroyen/ReSharperExtensions</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Live Templates Macros for writing test methods</description>
-    <summary />
-    <releaseNotes>Support for ReSharper 8.0</releaseNotes>
+    <releaseNotes>Support for ReSharper 8.1</releaseNotes>
     <copyright>Copyright © 2013 Joar Øyen</copyright>
     <language>en-US</language>
     <tags>Macro, Testing</tags>
@@ -18,6 +17,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\JoarOyen.ReSharperPlugIn\bin\Release\JoarOyen.ReSharperPlugIn.*" target="ReSharper\v8.0\plugins\" />
+    <file src="..\JoarOyen.ReSharperPlugIn\bin\Release\JoarOyen.ReSharperPlugIn.8.0.*" target="ReSharper\v8.0\plugins\" />
+    <file src="..\JoarOyen.ReSharperPlugIn\bin\Release\JoarOyen.ReSharperPlugIn.8.1.*" target="ReSharper\v8.1\plugins\" />
   </files>
 </package>

--- a/JoarOyen.ReSharperPlugIn.Tests/JoarOyen.ReSharperPlugIn.8.0.Tests.csproj
+++ b/JoarOyen.ReSharperPlugIn.Tests/JoarOyen.ReSharperPlugIn.8.0.Tests.csproj
@@ -5,14 +5,16 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{50B2B447-87A5-4222-97FC-4459310DA9DF}</ProjectGuid>
+    <ProjectGuid>{B1C3175A-4D88-46F0-83A7-25AA37B057FD}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>JoarOyen.ReSharperPlugIn</RootNamespace>
-    <AssemblyName>JoarOyen.ReSharperPlugIn</AssemblyName>
+    <RootNamespace>JoarOyen.ReSharperPlugIn.Tests</RootNamespace>
+    <AssemblyName>JoarOyen.ReSharperPlugIn.8.0.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,9 +24,6 @@
     <DefineConstants>JET_MODE_ASSERT;DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>
-    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,26 +34,34 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
+    <Reference Include="NSubstitute, Version=1.6.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NSubstitute.1.6.0.0\lib\NET40\NSubstitute.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CapitalizedWordsIdentifierMacro.cs" />
-    <Compile Include="CapitalizedWordsIdentifierMacroImpl.cs" />
-    <Compile Include="DomainAndUsernameMacro.cs" />
-    <Compile Include="DomainAndUsernameMacroImpl.cs" />
+    <Compile Include="DomainAndUsernameMacroTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="QuickParameterlessMacro.cs" />
-    <Compile Include="SimpleMacroDefinition.cs" />
-    <Compile Include="ValidIdentifierMacro.cs" />
-    <Compile Include="IdentifierBuilder.cs" />
-    <Compile Include="ValidIdentifierMacroImpl.cs" />
+    <Compile Include="QuickParameterlessMacroTests.cs" />
+    <Compile Include="SimpleMacroDefinitionTests.cs" />
+    <Compile Include="ValidIdentifierTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JoarOyen.ReSharperPlugIn\JoarOyen.ReSharperPlugIn.8.0.csproj">
+      <Project>{50B2B447-87A5-4222-97FC-4459310DA9DF}</Project>
+      <Name>JoarOyen.ReSharperPlugIn.8.0</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <PropertyGroup>
     <ReSharperSdkTargets Condition=" '$(ReSharperSdkTargets)' == '' ">$(MSBuildExtensionsPath)\JetBrains\ReSharper.SDK\v8.0</ReSharperSdkTargets>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ReSharperSdkTargets)\Plugin.Targets" />
+  <Import Project="$(ReSharperSdkTargets)\Plugin.Tests.Targets" />
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
 </Project>

--- a/JoarOyen.ReSharperPlugIn/JoarOyen.ReSharperPlugIn.8.0.csproj
+++ b/JoarOyen.ReSharperPlugIn/JoarOyen.ReSharperPlugIn.8.0.csproj
@@ -5,16 +5,14 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{B1C3175A-4D88-46F0-83A7-25AA37B057FD}</ProjectGuid>
+    <ProjectGuid>{50B2B447-87A5-4222-97FC-4459310DA9DF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>JoarOyen.ReSharperPlugIn.Tests</RootNamespace>
-    <AssemblyName>JoarOyen.ReSharperPlugIn.Tests</AssemblyName>
+    <RootNamespace>JoarOyen.ReSharperPlugIn</RootNamespace>
+    <AssemblyName>JoarOyen.ReSharperPlugIn.8.0</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,6 +22,9 @@
     <DefineConstants>JET_MODE_ASSERT;DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,34 +35,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NSubstitute, Version=1.6.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NSubstitute.1.6.0.0\lib\NET40\NSubstitute.dll</HintPath>
-    </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CapitalizedWordsIdentifierMacro.cs" />
-    <Compile Include="DomainAndUsernameMacroTests.cs" />
+    <Compile Include="CapitalizedWordsIdentifierMacroImpl.cs" />
+    <Compile Include="DomainAndUsernameMacro.cs" />
+    <Compile Include="DomainAndUsernameMacroImpl.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="QuickParameterlessMacroTests.cs" />
-    <Compile Include="SimpleMacroDefinitionTests.cs" />
-    <Compile Include="ValidIdentifierTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\JoarOyen.ReSharperPlugIn\JoarOyen.ReSharperPlugIn.csproj">
-      <Project>{50B2B447-87A5-4222-97FC-4459310DA9DF}</Project>
-      <Name>JoarOyen.ReSharperPlugIn</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <Compile Include="QuickParameterlessMacro.cs" />
+    <Compile Include="SimpleMacroDefinition.cs" />
+    <Compile Include="ValidIdentifierMacro.cs" />
+    <Compile Include="IdentifierBuilder.cs" />
+    <Compile Include="ValidIdentifierMacroImpl.cs" />
   </ItemGroup>
   <PropertyGroup>
     <ReSharperSdkTargets Condition=" '$(ReSharperSdkTargets)' == '' ">$(MSBuildExtensionsPath)\JetBrains\ReSharper.SDK\v8.0</ReSharperSdkTargets>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ReSharperSdkTargets)\Plugin.Tests.Targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(ReSharperSdkTargets)\Plugin.Targets" />
 </Project>

--- a/ReSharper81/JoarOyen.ReSharperPlugIn.Tests/JoarOyen.ReSharperPlugin.8.1.Tests.csproj
+++ b/ReSharper81/JoarOyen.ReSharperPlugIn.Tests/JoarOyen.ReSharperPlugin.8.1.Tests.csproj
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\JetBrains.ReSharper.SDK.Tests.8.1.231-EAP\build\JetBrains.ReSharper.SDK.Tests.Props" Condition="Exists('..\..\packages\JetBrains.ReSharper.SDK.Tests.8.1.231-EAP\build\JetBrains.ReSharper.SDK.Tests.Props')" />
+  <Import Project="..\..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Props" Condition="Exists('..\..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Props')" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.Tests.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Tests.Props" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Tests.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Tests.Props')" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Props" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Props')" />
+  <PropertyGroup>
+    <ReSharperSdkMode>Tests</ReSharperSdkMode>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6330F5DB-527D-40ED-8802-89064043A76F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>JoarOyen.ReSharperPlugin._8._1.Tests</RootNamespace>
+    <AssemblyName>JoarOyen.ReSharperPlugin.8.1.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\JoarOyen.ReSharperPlugIn.Tests\bin\Debug\</OutputPath>
+    <DefineConstants>JET_MODE_ASSERT;DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\JoarOyen.ReSharperPlugIn.Tests\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NSubstitute, Version=1.6.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NSubstitute.1.6.0.0\lib\NET40\NSubstitute.dll</HintPath>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn.Tests\CapitalizedWordsIdentifierMacro.cs">
+      <Link>CapitalizedWordsIdentifierMacro.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn.Tests\DomainAndUsernameMacroTests.cs">
+      <Link>DomainAndUsernameMacroTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn.Tests\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn.Tests\QuickParameterlessMacroTests.cs">
+      <Link>QuickParameterlessMacroTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn.Tests\SimpleMacroDefinitionTests.cs">
+      <Link>SimpleMacroDefinitionTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn.Tests\ValidIdentifierTests.cs">
+      <Link>ValidIdentifierTests.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JoarOyen.ReSharperPlugIn\JoarOyen.ReSharperPlugin.8.1.csproj">
+      <Project>{cc0e4ef7-05aa-4d5b-aee5-20fe4e0c7764}</Project>
+      <Name>JoarOyen.ReSharperPlugin.8.1</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Targets')" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Targets" Condition="Exists('..\..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Targets')" />
+</Project>

--- a/ReSharper81/JoarOyen.ReSharperPlugIn.Tests/packages.config
+++ b/ReSharper81/JoarOyen.ReSharperPlugIn.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="JetBrains.ReSharper.SDK" version="8.1.296-EAP" targetFramework="net40" />
+  <package id="JetBrains.ReSharper.SDK.Tests" version="8.1.231-EAP" targetFramework="net40" />
+  <package id="NSubstitute" version="1.6.0.0" targetFramework="net40" />
+</packages>

--- a/ReSharper81/JoarOyen.ReSharperPlugIn/JoarOyen.ReSharperPlugin.8.1.csproj
+++ b/ReSharper81/JoarOyen.ReSharperPlugIn/JoarOyen.ReSharperPlugin.8.1.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\JetBrains.ReSharper.SDK.8.1.231-EAP\build\JetBrains.ReSharper.SDK.Props" Condition="Exists('..\..\packages\JetBrains.ReSharper.SDK.8.1.231-EAP\build\JetBrains.ReSharper.SDK.Props')" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Props" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>JoarOyen.ReSharperPlugin._8._1</RootNamespace>
+    <AssemblyName>JoarOyen.ReSharperPlugin.8.1</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\JoarOyen.ReSharperPlugIn\bin\Debug\</OutputPath>
+    <DefineConstants>JET_MODE_ASSERT;DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\JoarOyen.ReSharperPlugIn\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>$(VsInstallDir)devenv.exe</StartProgram>
+    <StartArguments>/ReSharper.Plugin $(AssemblyName).dll /ReSharper.Internal</StartArguments>
+    <StartWorkingDirectory>$(MSBuildProjectDirectory)\$(OutputPath)</StartWorkingDirectory>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\CapitalizedWordsIdentifierMacro.cs">
+      <Link>CapitalizedWordsIdentifierMacro.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\CapitalizedWordsIdentifierMacroImpl.cs">
+      <Link>CapitalizedWordsIdentifierMacroImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\DomainAndUsernameMacro.cs">
+      <Link>DomainAndUsernameMacro.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\DomainAndUsernameMacroImpl.cs">
+      <Link>DomainAndUsernameMacroImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\IdentifierBuilder.cs">
+      <Link>IdentifierBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\QuickParameterlessMacro.cs">
+      <Link>QuickParameterlessMacro.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\SimpleMacroDefinition.cs">
+      <Link>SimpleMacroDefinition.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\ValidIdentifierMacro.cs">
+      <Link>ValidIdentifierMacro.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JoarOyen.ReSharperPlugIn\ValidIdentifierMacroImpl.cs">
+      <Link>ValidIdentifierMacroImpl.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.8.1.296-EAP\build\JetBrains.ReSharper.SDK.Targets')" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\JetBrains.ReSharper.SDK.8.1.231-EAP\build\JetBrains.ReSharper.SDK.Targets" Condition="Exists('..\..\packages\JetBrains.ReSharper.SDK.8.1.231-EAP\build\JetBrains.ReSharper.SDK.Targets')" />
+</Project>

--- a/ReSharper81/JoarOyen.ReSharperPlugIn/packages.config
+++ b/ReSharper81/JoarOyen.ReSharperPlugIn/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="JetBrains.ReSharper.SDK" version="8.1.231-EAP" targetFramework="net40" />
+</packages>

--- a/ReSharperExtensions.sln
+++ b/ReSharperExtensions.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{00465A82-90E8-4B47-8022-F159490A9C40}"
 	ProjectSection(SolutionItems) = preProject
 		BuildPackages.ps1 = BuildPackages.ps1
@@ -10,9 +12,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoarOyen.ReSharperPlugIn", "JoarOyen.ReSharperPlugIn\JoarOyen.ReSharperPlugIn.csproj", "{50B2B447-87A5-4222-97FC-4459310DA9DF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoarOyen.ReSharperPlugIn.8.0", "JoarOyen.ReSharperPlugIn\JoarOyen.ReSharperPlugIn.8.0.csproj", "{50B2B447-87A5-4222-97FC-4459310DA9DF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoarOyen.ReSharperPlugIn.Tests", "JoarOyen.ReSharperPlugIn.Tests\JoarOyen.ReSharperPlugIn.Tests.csproj", "{B1C3175A-4D88-46F0-83A7-25AA37B057FD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoarOyen.ReSharperPlugIn.8.0.Tests", "JoarOyen.ReSharperPlugIn.Tests\JoarOyen.ReSharperPlugIn.8.0.Tests.csproj", "{B1C3175A-4D88-46F0-83A7-25AA37B057FD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{EBC0E906-0655-41F9-B029-9AAE922081B5}"
 	ProjectSection(SolutionItems) = preProject
@@ -23,9 +25,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{EBC0E9
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{C8DD8158-6BB4-4471-A720-AE800D08A6E6}"
 	ProjectSection(SolutionItems) = preProject
-		Deploy\JoarOyen.ReSharperExtensions.LiveTemplates.8.0.0.1.nuspec = Deploy\JoarOyen.ReSharperExtensions.LiveTemplates.8.0.0.1.nuspec
-		Deploy\JoarOyen.ReSharperExtensions.Macros.8.0.0.1.nuspec = Deploy\JoarOyen.ReSharperExtensions.Macros.8.0.0.1.nuspec
+		Deploy\JoarOyen.ReSharperExtensions.LiveTemplates.nuspec = Deploy\JoarOyen.ReSharperExtensions.LiveTemplates.nuspec
+		Deploy\JoarOyen.ReSharperExtensions.Macros.nuspec = Deploy\JoarOyen.ReSharperExtensions.Macros.nuspec
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReSharper-8.0", "ReSharper-8.0", "{41554525-94DE-48CB-A1D0-9E0B706E179E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReSharper-8.1", "ReSharper-8.1", "{28FF66CA-CB7A-43DA-823A-9ED242899D3D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoarOyen.ReSharperPlugin.8.1", "ReSharper81\JoarOyen.ReSharperPlugIn\JoarOyen.ReSharperPlugin.8.1.csproj", "{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoarOyen.ReSharperPlugin.8.1.Tests", "ReSharper81\JoarOyen.ReSharperPlugIn.Tests\JoarOyen.ReSharperPlugin.8.1.Tests.csproj", "{6330F5DB-527D-40ED-8802-89064043A76F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,8 +67,34 @@ Global
 		{B1C3175A-4D88-46F0-83A7-25AA37B057FD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{B1C3175A-4D88-46F0-83A7-25AA37B057FD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B1C3175A-4D88-46F0-83A7-25AA37B057FD}.Release|x86.ActiveCfg = Release|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764}.Release|x86.ActiveCfg = Release|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6330F5DB-527D-40ED-8802-89064043A76F}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B1C3175A-4D88-46F0-83A7-25AA37B057FD} = {41554525-94DE-48CB-A1D0-9E0B706E179E}
+		{50B2B447-87A5-4222-97FC-4459310DA9DF} = {41554525-94DE-48CB-A1D0-9E0B706E179E}
+		{CC0E4EF7-05AA-4D5B-AEE5-20FE4E0C7764} = {28FF66CA-CB7A-43DA-823A-9ED242899D3D}
+		{6330F5DB-527D-40ED-8802-89064043A76F} = {28FF66CA-CB7A-43DA-823A-9ED242899D3D}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Supports both 8.0 and 8.1 for each package. Means building 8.0 and 8.1 at the same time. Since the 8.1 SDK is now distributed by nuget, that means it alters the packages.config file, but that's already in use for the 8.0 project. So, the 8.1 projects are in a ReSharper81 folder. Not ideal, but will be fixed in nuget 2.8, which allows for packages.projectname.config.

Alternatively, could commit the 8.0 binaries, build 8.1 and bundle both into the package. Let me know if you'd prefer this, and I can update the PR.
